### PR TITLE
Add initial task backlog for codebase improvement work

### DIFF
--- a/tasks/done/task_1_bug_fixes.md
+++ b/tasks/done/task_1_bug_fixes.md
@@ -1,0 +1,75 @@
+# Bug Fixes
+
+**Priority:** 01
+**Created:** 2026-03-16
+**Effort:** Low
+**Risk:** None
+
+## What
+
+Fix three confirmed bugs: two off-by-one writes in `json.c` and ~11 uses of unsafe `sprintf` in the serializer, plus dead/broken key-truncation logic in `hash_table.c`.
+
+## Why
+
+These are correctness issues, not style. The off-by-one writes one byte past the end of their allocation (undefined behaviour). The `sprintf` calls bypass the bounds check that precedes them, making buffer overflows possible if the check logic ever changes. The truncation guard in `hash_table.c` can never trigger, leaving misleading dead code.
+
+## How
+
+### 1. Off-by-one in `json.c` (2 instances)
+
+**`src/json.c:366`**
+
+```c
+// BEFORE
+key_buffer = calloc(1, key_len + 1);
+memcpy(key_buffer, start, key_len);
+key_buffer[key_len + 1] = '\0';   // writes one byte past the allocation
+
+// AFTER
+key_buffer = calloc(1, key_len + 1);
+memcpy(key_buffer, start, key_len);
+key_buffer[key_len] = '\0';
+```
+
+A duplicate of this same bug exists around line 568 in the `parse_string` function. Apply the same fix there.
+
+### 2. Unsafe `sprintf` in `json.c` serializer (~11 call sites, lines 728–855)
+
+Every branch in the `switch` statement uses this two-step pattern:
+
+```c
+// BEFORE
+val_len = snprintf(NULL, 0, fmt, args);      // measure
+if (val_len > len - *pos) return -1;         // bounds check
+sprintf(buffer + *pos, fmt, args);            // unsafe write
+*pos += val_len;
+
+// AFTER
+val_len = snprintf(buffer + *pos, len - *pos, fmt, args);
+if (val_len < 0 || (size_t)val_len >= len - *pos) return -1;
+*pos += val_len;
+```
+
+`snprintf` returns the number of characters that *would* have been written. If that exceeds the remaining capacity it means nothing useful was written, so we return -1. This replaces the unsafe `sprintf` and removes the redundant first `snprintf` call in one step.
+
+Affected lines (approximate): 724–728, 735–739, 747–751, 759–763, 773–777, 784–788, 793–797, 806–810, 816–820, 827–831, 841–845. Search for `sprintf(buffer` in `src/json.c` to find all instances.
+
+### 3. Dead truncation logic in `hash_table.c:73-79`
+
+```c
+// BEFORE
+char* hash_key = strdup(key);
+size_t len = strnlen(hash_key, MAX_KEY_LENGTH - 1);   // caps at MAX_KEY_LENGTH-1
+
+if (len > MAX_KEY_LENGTH) {    // can never be true
+    LOG(ERROR, ...);
+    hash_key[MAX_KEY_LENGTH] = '\0';
+}
+
+// AFTER
+char* hash_key = strdup(key);
+// No truncation block needed; strnlen already caps the hash computation.
+// If key length validation is desired, check before calling insert.
+```
+
+Remove lines 75–79 (the `if (len > MAX_KEY_LENGTH)` block). The `len` variable is still used by `get_hash_index` implicitly via the loop — verify `get_hash_index` uses its own `strnlen` call (it does, at line 45) so the local `len` variable after the `strdup` is unused and can be removed too.

--- a/tasks/todo/task_10_create_ptr_array_utility.md
+++ b/tasks/todo/task_10_create_ptr_array_utility.md
@@ -1,0 +1,152 @@
+# Create `ptr_array_t` Dynamic Array Utility
+
+**Priority:** 10
+**Created:** 2026-03-16
+**Effort:** Small
+**Risk:** None (new code, no existing code changed)
+**Prerequisite for:** Tasks 12, 13, 14
+
+## What
+
+Add a simple dynamic (growable) pointer array to `src/data/` following the same conventions as the existing `linked_list` and `hash_table` data structures. This will be used to replace `linked_list_t` wherever sequential, index-accessible storage is needed.
+
+## Why
+
+Three hot-path linked lists (`game->systems`, `game->archetypes`, `game->tasks`) are iterated every tick or on every component change. A contiguous array of pointers allows the CPU prefetcher to work effectively — all pointers are in a single allocation that can be walked with a plain `for` loop, with no indirection through separately allocated `node_t` structs.
+
+The existing `linked_list_t` stays in place for the event queue (FIFO) where it is the correct choice.
+
+## How
+
+### Files to create
+
+**`include/mud/data/ptr_array.h`**
+
+```c
+#ifndef MUD_DATA_PTR_ARRAY_H
+#define MUD_DATA_PTR_ARRAY_H
+
+#include <stddef.h>
+
+typedef struct ptr_array {
+  void**  items;
+  size_t  count;
+  size_t  capacity;
+  void  (*deallocator)(void*);
+} ptr_array_t;
+
+ptr_array_t* ptr_array_new(void);
+void         ptr_array_free(ptr_array_t* arr);
+
+int  ptr_array_push(ptr_array_t* arr, void* item);
+int  ptr_array_remove(ptr_array_t* arr, void* item);
+
+#endif
+```
+
+**`src/data/ptr_array/ptr_array.c`**
+
+```c
+#include "mud/data/ptr_array.h"
+#include "mud/log.h"
+
+#include <assert.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define PTR_ARRAY_INITIAL_CAPACITY 8
+
+ptr_array_t* ptr_array_new(void) {
+  ptr_array_t* arr = calloc(1, sizeof *arr);
+  if (!arr) return NULL;
+
+  arr->items = calloc(PTR_ARRAY_INITIAL_CAPACITY, sizeof(void*));
+  if (!arr->items) { free(arr); return NULL; }
+
+  arr->capacity = PTR_ARRAY_INITIAL_CAPACITY;
+  return arr;
+}
+
+void ptr_array_free(ptr_array_t* arr) {
+  if (!arr) return;
+
+  if (arr->deallocator) {
+    for (size_t i = 0; i < arr->count; i++) {
+      arr->deallocator(arr->items[i]);
+    }
+  }
+
+  free(arr->items);
+  free(arr);
+}
+
+/* Append an item, growing the backing buffer by doubling if necessary.
+ * Returns 0 on success, -1 on allocation failure. */
+int ptr_array_push(ptr_array_t* arr, void* item) {
+  assert(arr);
+  assert(item);
+
+  if (arr->count == arr->capacity) {
+    size_t new_cap = arr->capacity * 2;
+    void** new_items = realloc(arr->items, new_cap * sizeof(void*));
+
+    if (!new_items) {
+      LOG(ERROR, "ptr_array_push: realloc failed growing to capacity %zu", new_cap);
+      return -1;
+    }
+
+    arr->items    = new_items;
+    arr->capacity = new_cap;
+  }
+
+  arr->items[arr->count++] = item;
+  return 0;
+}
+
+/* Remove the first occurrence of item (by pointer equality).
+ * Calls the deallocator if one is set.
+ * Remaining items are shifted left to fill the gap — O(n) but arrays are small.
+ * Returns 0 if found and removed, -1 if not found. */
+int ptr_array_remove(ptr_array_t* arr, void* item) {
+  assert(arr);
+  assert(item);
+
+  for (size_t i = 0; i < arr->count; i++) {
+    if (arr->items[i] == item) {
+      if (arr->deallocator) {
+        arr->deallocator(arr->items[i]);
+      }
+
+      /* Shift everything after i left by one */
+      size_t tail = arr->count - i - 1;
+      if (tail > 0) {
+        memmove(&arr->items[i], &arr->items[i + 1], tail * sizeof(void*));
+      }
+
+      arr->count--;
+      return 0;
+    }
+  }
+
+  return -1;
+}
+```
+
+### Iteration pattern
+
+Callers iterate using a plain `for` loop — no iterator type needed:
+
+```c
+for (size_t i = 0; i < arr->count; i++) {
+  my_type_t* item = (my_type_t*)arr->items[i];
+  // use item
+}
+```
+
+### Add to CMakeLists.txt
+
+`CMakeLists.txt` uses `file(GLOB_RECURSE SRC_FILES ...)` so the new `.c` file is picked up automatically. No changes needed.
+
+### Verification
+
+Build cleanly. Unit-test manually by registering a system and confirming it executes each tick. The three consumer tasks (12, 13, 14) provide the real integration test.

--- a/tasks/todo/task_11_archetype_components_inline_array.md
+++ b/tasks/todo/task_11_archetype_components_inline_array.md
@@ -1,0 +1,168 @@
+# Replace `archetype->components` Linked List with Inline Fixed Array
+
+**Priority:** 11
+**Created:** 2026-03-16
+**Effort:** Small–Medium
+**Risk:** Low
+**Dependencies:** None (self-contained to `archetype.h` / `archetype.c`)
+
+## What
+
+Replace the `linked_list_t* components` field in `archetype_t` with a fixed-size inline array of `component_t*` pointers and an integer count. Remove the heap allocation for this list entirely.
+
+## Why
+
+`archetype->components` is iterated inside `ecs_entity_matches_archetype`, which is called from `ecs_update_entity_archetypes`, which is called every time any entity gains or loses a component. It is the innermost loop of the ECS hot path:
+
+```
+component add/remove
+  → ecs_update_entity_archetypes (iterates game->archetypes)
+      → ecs_entity_matches_archetype (iterates archetype->components)
+          → ecs_component_has_entity (hash table lookup)
+```
+
+The list is always small (2–5 components per archetype), never changes after the archetype is registered, and is never iterated except in this one function. A fixed inline array eliminates the heap allocation for the list and all of its nodes, removes the `it_t` iterator machinery from the hot loop, and reduces the function to a plain `for` loop over contiguous memory.
+
+## How
+
+### 1. Define a capacity constant and update the struct — `include/mud/ecs/archetype.h`
+
+```c
+#define MAX_ARCHETYPE_COMPONENTS 16
+
+typedef struct archetype {
+  hash_table_t* entities;
+  component_t*  components[MAX_ARCHETYPE_COMPONENTS];
+  int           component_count;
+} archetype_t;
+```
+
+Remove the forward declaration of `linked_list_t` from this header — it is no longer needed. Remove the `#include` or typedef for `linked_list_t` if it has no other use in the file.
+
+Update the signature of `ecs_update_entity_archetypes` — it currently takes `linked_list_t* archetypes` because the archetypes themselves were stored in a linked list. This will change in task 13; leave the signature as-is for now and update it as part of task 13.
+
+### 2. Update `ecs_new_archetype_t` — `src/ecs/archetype.c`
+
+```c
+// BEFORE
+archetype_t* ecs_new_archetype_t() {
+  archetype_t* archetype = calloc(1, sizeof(archetype_t));
+  archetype->components = create_linked_list_t();
+  archetype->entities = create_hash_table_t();
+  return archetype;
+}
+
+// AFTER
+archetype_t* ecs_new_archetype_t() {
+  archetype_t* archetype = calloc(1, sizeof *archetype);
+  if (!archetype) return NULL;
+  archetype->entities = create_hash_table_t();
+  // components array and component_count are zero-initialised by calloc
+  return archetype;
+}
+```
+
+### 3. Update `ecs_free_archetype_t` — `src/ecs/archetype.c`
+
+```c
+// BEFORE
+void ecs_free_archetype_t(archetype_t* archetype) {
+  assert(archetype);
+  free_linked_list_t(archetype->components);
+  free_hash_table_t(archetype->entities);
+  free(archetype);
+}
+
+// AFTER
+void ecs_free_archetype_t(archetype_t* archetype) {
+  assert(archetype);
+  // components are not owned by the archetype — they are pointers to
+  // component_t instances owned by game->components. Do not free them.
+  free_hash_table_t(archetype->entities);
+  free(archetype);
+}
+```
+
+### 4. Update `ecs_add_archetype_component` — `src/ecs/archetype.c`
+
+```c
+// BEFORE
+void ecs_add_archetype_component(archetype_t* archetype, component_t* component) {
+  list_add(archetype->components, component);
+}
+
+// AFTER
+void ecs_add_archetype_component(archetype_t* archetype, component_t* component) {
+  assert(archetype);
+  assert(component);
+  assert(archetype->component_count < MAX_ARCHETYPE_COMPONENTS);
+
+  archetype->components[archetype->component_count++] = component;
+}
+```
+
+### 5. Update `ecs_remove_archetype_component` — `src/ecs/archetype.c`
+
+```c
+// BEFORE
+void ecs_remove_archetype_component(archetype_t* archetype, component_t* component) {
+  list_remove(archetype->components, component);
+}
+
+// AFTER
+void ecs_remove_archetype_component(archetype_t* archetype, component_t* component) {
+  assert(archetype);
+  assert(component);
+
+  for (int i = 0; i < archetype->component_count; i++) {
+    if (archetype->components[i] == component) {
+      // Shift remaining pointers left
+      int tail = archetype->component_count - i - 1;
+      if (tail > 0) {
+        memmove(&archetype->components[i], &archetype->components[i + 1],
+                tail * sizeof(component_t*));
+      }
+      archetype->component_count--;
+      return;
+    }
+  }
+}
+```
+
+Add `#include <string.h>` at the top of `archetype.c` for `memmove`.
+
+### 6. Update `ecs_entity_matches_archetype` — `src/ecs/archetype.c`
+
+```c
+// BEFORE
+bool ecs_entity_matches_archetype(archetype_t* archetype, entity_t* entity) {
+  it_t it = list_begin(archetype->components);
+  component_t* component = NULL;
+
+  while ((component = it_get(it)) != NULL) {
+    if (!ecs_component_has_entity(component, entity)) {
+      return false;
+    }
+    it = it_next(it);
+  }
+  return true;
+}
+
+// AFTER
+bool ecs_entity_matches_archetype(archetype_t* archetype, entity_t* entity) {
+  for (int i = 0; i < archetype->component_count; i++) {
+    if (!ecs_component_has_entity(archetype->components[i], entity)) {
+      return false;
+    }
+  }
+  return true;
+}
+```
+
+### 7. Remove unused includes from `archetype.c`
+
+Remove `#include "mud/data/linked_list.h"` if it is no longer referenced anywhere in the file after these changes.
+
+### Verification
+
+Build cleanly. Start the game, register an archetype from Lua, add and remove components on an entity, and confirm the archetype membership updates correctly via `game.get_archetype_entities`.

--- a/tasks/todo/task_12_game_systems_dynamic_array.md
+++ b/tasks/todo/task_12_game_systems_dynamic_array.md
@@ -1,0 +1,133 @@
+# Replace `game->systems` Linked List with Dynamic Array
+
+**Priority:** 12
+**Created:** 2026-03-16
+**Effort:** Small–Medium
+**Risk:** Low
+**Dependencies:** Task 10 (`ptr_array_t` utility must exist first)
+
+## What
+
+Replace the `linked_list_t* systems` field in `game_t` with a `ptr_array_t* systems`, updating all sites that add, remove, or iterate systems.
+
+## Why
+
+`game->systems` is iterated on every game tick via `ecs_update_systems` (`src/ecs/system.c:84`). This is called unconditionally in the main loop (`src/game.c:188`). With a linked list, each iteration step dereferences a separately-allocated `node_t` pointer before reaching the `system_t`. A `ptr_array_t` stores all system pointers contiguously so the loop walks a single flat allocation — no intermediate node dereferences.
+
+Systems are registered at startup (or occasionally at runtime from Lua) and almost never removed. The remove operation is O(n) with a dynamic array, which is acceptable for a collection that stays small and static.
+
+## How
+
+### 1. Update `game_t` — `include/mud/game.h`
+
+```c
+// Add forward declaration / include for ptr_array_t
+typedef struct ptr_array ptr_array_t;
+
+typedef struct game {
+  // ... existing fields ...
+  ptr_array_t* components;   // was linked_list_t*
+  ptr_array_t* archetypes;   // was linked_list_t*  (done in task 13)
+  ptr_array_t* systems;      // was linked_list_t*
+  // tasks and events remain for now
+  // ...
+} game_t;
+```
+
+Change only `systems` as part of this task. `components` and `archetypes` are handled in task 13. Keep `linked_list_t* tasks` and `linked_list_t* events` unchanged.
+
+### 2. Update `create_game_t` — `src/game.c`
+
+```c
+// BEFORE
+game->systems = create_linked_list_t();
+game->systems->deallocator = ecs_deallocate_system_t;
+
+// AFTER
+game->systems = ptr_array_new();
+game->systems->deallocator = ecs_deallocate_system_t;
+```
+
+### 3. Update `free_game_t` — `src/game.c`
+
+```c
+// BEFORE
+free_linked_list_t(game->systems);
+
+// AFTER
+ptr_array_free(game->systems);
+```
+
+### 4. Update `ecs_update_systems` — `src/ecs/system.c`
+
+Change the signature of `ecs_update_systems` and update `include/mud/ecs/system.h` to match.
+
+```c
+// BEFORE (system.h)
+void ecs_update_systems(game_t* game);
+
+// AFTER — no signature change needed; game_t is passed and systems accessed from it
+```
+
+The implementation changes from linked list iteration to a plain for loop:
+
+```c
+// BEFORE
+void ecs_update_systems(game_t* game) {
+  it_t it = list_begin(game->systems);
+  system_t* system = NULL;
+
+  while ((system = it_get(it)) != NULL) {
+    if (system->enabled) {
+      if (lua_call_system_execute_hook(game->lua_state, system) == -1) {
+        LOG(ERROR, "Failed to execute system");
+      }
+    }
+    it = it_next(it);
+  }
+}
+
+// AFTER
+void ecs_update_systems(game_t* game) {
+  for (size_t i = 0; i < game->systems->count; i++) {
+    system_t* system = (system_t*)game->systems->items[i];
+
+    if (system->enabled) {
+      if (lua_call_system_execute_hook(game->lua_state, system) == -1) {
+        LOG(ERROR, "Failed to execute system");
+      }
+    }
+  }
+}
+```
+
+Add `#include "mud/data/ptr_array.h"` to `system.c`.
+
+### 5. Update Lua API — `src/lua/game_api.c`
+
+Find all sites in `game_api.c` that add to or remove from `game->systems` (register/deregister system calls). Replace `list_add` / `list_remove` with `ptr_array_push` / `ptr_array_remove`:
+
+```c
+// BEFORE
+list_add(game->systems, system);
+list_remove(game->systems, system);
+
+// AFTER
+ptr_array_push(game->systems, system);
+ptr_array_remove(game->systems, system);
+```
+
+Search `src/lua/game_api.c` for `game->systems` to find all call sites.
+
+### 6. Update includes
+
+In `src/game.c` and `src/ecs/system.c`, add:
+```c
+#include "mud/data/ptr_array.h"
+```
+
+If `linked_list.h` is no longer referenced in these files after the change, remove its include.
+
+### Verification
+
+Build cleanly. Start the server and confirm that systems registered from Lua execute each tick. Register multiple systems; deregister one; confirm remaining systems still execute. The behaviour is identical — only the internal iteration mechanism changes.

--- a/tasks/todo/task_13_game_archetypes_components_dynamic_array.md
+++ b/tasks/todo/task_13_game_archetypes_components_dynamic_array.md
@@ -1,0 +1,182 @@
+# Replace `game->archetypes` and `game->components` Linked Lists with Dynamic Arrays
+
+**Priority:** 13
+**Created:** 2026-03-16
+**Effort:** Medium
+**Risk:** Low–Medium (signature change propagates to component.c and Lua API)
+**Dependencies:** Task 10 (`ptr_array_t`), Task 11 (archetype->components inline array)
+
+## What
+
+Replace `linked_list_t* archetypes` and `linked_list_t* components` in `game_t` with `ptr_array_t*`. Update all call sites, including the signature of `ecs_update_entity_archetypes` and `ecs_remove_entity_from_all_components` which currently accept `linked_list_t*` directly.
+
+## Why
+
+`game->archetypes` is iterated inside `ecs_update_entity_archetypes` every time any entity gains or loses a component (triggered via `ecs_add_entity_to_component` and `ecs_remove_entity_from_component` in `component.c`). This is the outer loop of the ECS hot path (task 11 addresses the inner loop). Converting to a `ptr_array_t` removes per-node pointer chasing from this traversal.
+
+`game->components` is iterated in `ecs_remove_entity_from_all_components`, called when an entity is deleted. Although this is a cold path, converting it is low-effort once the archetype change is done, and maintains consistency.
+
+## How
+
+### 1. Update `game_t` — `include/mud/game.h`
+
+```c
+typedef struct game {
+  // ...
+  ptr_array_t* components;   // was linked_list_t*
+  ptr_array_t* archetypes;   // was linked_list_t*
+  ptr_array_t* systems;      // already changed in task 12
+  // ...
+} game_t;
+```
+
+Ensure `ptr_array_t` is forward-declared in this header (may already be present from task 12).
+
+### 2. Update `create_game_t` — `src/game.c`
+
+```c
+// BEFORE
+game->components = create_linked_list_t();
+game->components->deallocator = ecs_deallocate_component_t;
+
+game->archetypes = create_linked_list_t();
+game->archetypes->deallocator = ecs_deallocate_archetype_t;
+
+// AFTER
+game->components = ptr_array_new();
+game->components->deallocator = ecs_deallocate_component_t;
+
+game->archetypes = ptr_array_new();
+game->archetypes->deallocator = ecs_deallocate_archetype_t;
+```
+
+### 3. Update `free_game_t` — `src/game.c`
+
+```c
+// BEFORE
+free_linked_list_t(game->components);
+free_linked_list_t(game->archetypes);
+
+// AFTER
+ptr_array_free(game->components);
+ptr_array_free(game->archetypes);
+```
+
+### 4. Update `ecs_update_entity_archetypes` — `src/ecs/archetype.c` and `archetype.h`
+
+This function's signature currently takes `linked_list_t* archetypes`. Update it to take `ptr_array_t*`.
+
+**`include/mud/ecs/archetype.h`:**
+```c
+// Add forward declaration
+typedef struct ptr_array ptr_array_t;
+
+// Change signature
+void ecs_update_entity_archetypes(ptr_array_t* archetypes, entity_t* entity);
+```
+
+**`src/ecs/archetype.c`:**
+```c
+// BEFORE
+void ecs_update_entity_archetypes(linked_list_t* archetypes, entity_t* entity) {
+  it_t it = list_begin(archetypes);
+  archetype_t* archetype = NULL;
+
+  while ((archetype = it_get(it)) != NULL) {
+    if (ecs_entity_matches_archetype(archetype, entity)) {
+      if (!ecs_archetype_has_entity(archetype, entity)) {
+        ecs_add_entity_to_archetype(archetype, entity);
+      }
+    } else {
+      if (ecs_archetype_has_entity(archetype, entity)) {
+        ecs_remove_entity_from_archetype(archetype, entity);
+      }
+    }
+    it = it_next(it);
+  }
+}
+
+// AFTER
+void ecs_update_entity_archetypes(ptr_array_t* archetypes, entity_t* entity) {
+  for (size_t i = 0; i < archetypes->count; i++) {
+    archetype_t* archetype = (archetype_t*)archetypes->items[i];
+
+    if (ecs_entity_matches_archetype(archetype, entity)) {
+      if (!ecs_archetype_has_entity(archetype, entity)) {
+        ecs_add_entity_to_archetype(archetype, entity);
+      }
+    } else {
+      if (ecs_archetype_has_entity(archetype, entity)) {
+        ecs_remove_entity_from_archetype(archetype, entity);
+      }
+    }
+  }
+}
+```
+
+### 5. Update `ecs_remove_entity_from_all_components` — `src/ecs/component.c` and `component.h`
+
+**`include/mud/ecs/component.h`:**
+```c
+// Change signatures for both functions that take linked_list_t* for components/archetypes
+void ecs_add_entity_to_component(component_t* component, component_data_t* data,
+                                  ptr_array_t* archetypes, entity_t* entity);
+void ecs_remove_entity_from_component(component_t* component,
+                                       ptr_array_t* archetypes, entity_t* entity);
+void ecs_remove_entity_from_all_components(ptr_array_t* components,
+                                            ptr_array_t* archetypes, entity_t* entity);
+```
+
+**`src/ecs/component.c`** — update `ecs_remove_entity_from_all_components`:
+```c
+// BEFORE
+void ecs_remove_entity_from_all_components(linked_list_t* components,
+                                            linked_list_t* archetypes, entity_t* entity) {
+  it_t it = list_begin(components);
+  component_t* component = NULL;
+
+  while ((component = it_get(it)) != NULL) {
+    ecs_remove_entity_from_component(component, archetypes, entity);
+    it = it_next(it);
+  }
+}
+
+// AFTER
+void ecs_remove_entity_from_all_components(ptr_array_t* components,
+                                            ptr_array_t* archetypes, entity_t* entity) {
+  for (size_t i = 0; i < components->count; i++) {
+    component_t* component = (component_t*)components->items[i];
+    ecs_remove_entity_from_component(component, archetypes, entity);
+  }
+}
+```
+
+The other two functions (`ecs_add_entity_to_component`, `ecs_remove_entity_from_component`) already pass `archetypes` through to `ecs_update_entity_archetypes` — update their parameter type from `linked_list_t*` to `ptr_array_t*` and their call to `ecs_update_entity_archetypes` remains the same (just with the new type).
+
+### 6. Update Lua API call sites — `src/lua/game_api.c`
+
+Find all sites that add to or remove from `game->archetypes` or `game->components`:
+
+```
+grep -n "game->archetypes\|game->components" src/lua/game_api.c
+```
+
+Replace `list_add` with `ptr_array_push`. There are no mid-runtime removals of archetypes or components expected, but if `list_remove` appears, replace with `ptr_array_remove`.
+
+### 7. Update `ecs_remove_entity_from_all_components` call site
+
+The call in `src/ecs/entity.c` (entity deletion) passes `game->components` and `game->archetypes`:
+
+```
+grep -n "ecs_remove_entity_from_all_components" src/
+```
+
+No change to the logic, just the type of the arguments now matches `ptr_array_t*`.
+
+### 8. Remove unused includes
+
+After changes, remove `#include "mud/data/linked_list.h"` from any file that no longer uses `linked_list_t`. Add `#include "mud/data/ptr_array.h"` wherever needed.
+
+### Verification
+
+Build with zero warnings (clang-tidy runs automatically). Start the game. From Lua, register archetypes and components, create entities, add/remove components, and verify archetype membership updates correctly via `game.get_archetype_entities` and `game.matches_archetype`. Delete an entity and confirm no component or archetype state is left dangling.

--- a/tasks/todo/task_14_game_tasks_dynamic_array.md
+++ b/tasks/todo/task_14_game_tasks_dynamic_array.md
@@ -1,0 +1,193 @@
+# Replace `game->tasks` Linked List with Sorted Dynamic Array
+
+**Priority:** 14
+**Created:** 2026-03-16
+**Effort:** Medium
+**Risk:** Low–Medium (changes task execution logic)
+**Dependencies:** Task 10 (`ptr_array_t` utility)
+
+## What
+
+Replace `linked_list_t* tasks` in `game_t` with a `ptr_array_t*` kept sorted by `task->execute_at`. Update `task_schedule_task`, `task_cancel_task`, and `task_execute_tasks` accordingly.
+
+## Why
+
+`task_execute_tasks` is called every game tick (`src/game.c:187`). Currently it:
+1. Allocates a second temporary `linked_list_t` (`ready_tasks`)
+2. Calls `list_extract` to scan and move ready tasks into it
+3. Iterates `ready_tasks` to execute them
+4. Frees the temporary list
+
+This allocates and frees a linked list every tick. With a sorted dynamic array, ready tasks are always at the front (index 0 upward). The tick scan can break as soon as it hits a future task — no temporary list, no allocation, and fewer items examined on average.
+
+`task_cancel_task` (removal by pointer) is O(n) on both structures; cost is unchanged.
+
+## How
+
+### 1. Update `task.h` — `include/mud/task.h`
+
+Replace the `linked_list_t` typedef and all function signatures:
+
+```c
+#ifndef MUD_TASK_TASK_H
+#define MUD_TASK_TASK_H
+
+#include <time.h>
+#include "mud/util/muduuid.h"
+
+typedef struct game     game_t;
+typedef struct ptr_array ptr_array_t;
+typedef struct lua_ref  lua_ref_t;
+
+typedef struct task {
+  mud_uuid_t uuid;
+  char*      name;
+  time_t     execute_at;
+  lua_ref_t* ref;
+} task_t;
+
+task_t* task_new_task_t(const char* name, int execute_in, lua_ref_t* ref);
+void    task_free_task_t(task_t* task);
+void    task_deallocate_task_t(void* value);
+
+int task_schedule_task(ptr_array_t* tasks, task_t* task);
+int task_cancel_task(ptr_array_t* tasks, game_t* game, task_t* task);
+int task_execute_tasks(ptr_array_t* tasks, game_t* game);
+
+#endif
+```
+
+### 2. Update `create_game_t` and `free_game_t` — `src/game.c`
+
+```c
+// BEFORE
+game->tasks = create_linked_list_t();
+game->tasks->deallocator = task_deallocate_task_t;
+// ...
+free_linked_list_t(game->tasks);
+
+// AFTER
+game->tasks = ptr_array_new();
+game->tasks->deallocator = task_deallocate_task_t;
+// ...
+ptr_array_free(game->tasks);
+```
+
+### 3. Implement `task_schedule_task` with sorted insertion — `src/task.c`
+
+Insert new tasks in ascending `execute_at` order so that the tasks due soonest are always at the front of the array. This makes `task_execute_tasks` able to break early.
+
+```c
+int task_schedule_task(ptr_array_t* tasks, task_t* task) {
+  assert(tasks);
+  assert(task);
+
+  // Find the insertion point (first task with execute_at > task->execute_at)
+  size_t insert_at = tasks->count;
+  for (size_t i = 0; i < tasks->count; i++) {
+    task_t* existing = (task_t*)tasks->items[i];
+    if (existing->execute_at > task->execute_at) {
+      insert_at = i;
+      break;
+    }
+  }
+
+  // Grow if needed (reuse ptr_array_push logic, but we need to insert mid-array)
+  if (tasks->count == tasks->capacity) {
+    size_t new_cap = tasks->capacity * 2;
+    void** new_items = realloc(tasks->items, new_cap * sizeof(void*));
+    if (!new_items) {
+      LOG(ERROR, "task_schedule_task: realloc failed");
+      return -1;
+    }
+    tasks->items    = new_items;
+    tasks->capacity = new_cap;
+  }
+
+  // Shift items from insert_at onward to make room
+  size_t tail = tasks->count - insert_at;
+  if (tail > 0) {
+    memmove(&tasks->items[insert_at + 1], &tasks->items[insert_at],
+            tail * sizeof(void*));
+  }
+
+  tasks->items[insert_at] = task;
+  tasks->count++;
+  return 0;
+}
+```
+
+Add `#include <string.h>` at the top of `task.c` for `memmove`.
+
+Note: If the sorted insertion is considered too complex and task counts are expected to remain small (<50), an alternative is to use plain `ptr_array_push` and accept an unsorted array. `task_execute_tasks` would then scan all items rather than breaking early. This is simpler to implement and still eliminates the per-tick temporary list allocation.
+
+### 4. Implement `task_execute_tasks` with early exit — `src/task.c`
+
+```c
+int task_execute_tasks(ptr_array_t* tasks, game_t* game) {
+  assert(tasks);
+
+  time_t now = time(NULL);
+  size_t i = 0;
+
+  while (i < tasks->count) {
+    task_t* task = (task_t*)tasks->items[i];
+
+    if (task->execute_at > now) {
+      break;  // Array is sorted; no later tasks are ready
+    }
+
+    lua_call_task_execute_hook(game->lua_state, task);
+
+    // Remove this task: shift remaining items left and free the task
+    size_t tail = tasks->count - i - 1;
+    if (tail > 0) {
+      memmove(&tasks->items[i], &tasks->items[i + 1], tail * sizeof(void*));
+    }
+    tasks->count--;
+
+    task_free_task_t(task);
+    // Do NOT increment i — the item at index i is now the next task
+  }
+
+  return 0;
+}
+```
+
+Note: The task is freed directly here rather than through the deallocator, because we are removing it without going through `ptr_array_remove` (to avoid a second O(n) search). This is correct — no double-free occurs.
+
+### 5. Implement `task_cancel_task` — `src/task.c`
+
+```c
+int task_cancel_task(ptr_array_t* tasks, game_t* game, task_t* task) {
+  assert(tasks);
+  assert(task);
+
+  (void)game;  // game parameter retained for API compatibility; unused
+
+  if (ptr_array_remove(tasks, task) != 0) {
+    LOG(ERROR, "task_cancel_task: task not found in task list");
+    return -1;
+  }
+
+  return 0;
+}
+```
+
+`ptr_array_remove` calls the deallocator on the item. Since `tasks->deallocator = task_deallocate_task_t`, the task is freed correctly.
+
+### 6. Remove the `task_is_ready_to_execute` predicate
+
+The static predicate function used by `list_extract` is no longer needed. Remove it:
+
+```
+grep -n "task_is_ready_to_execute" src/task.c
+```
+
+### 7. Update includes in `src/task.c`
+
+Add `#include "mud/data/ptr_array.h"`. Remove `#include "mud/data/linked_list.h"` if no longer used.
+
+### Verification
+
+Build cleanly. Start the game. Schedule several tasks from Lua with different delays (e.g., 1s, 5s, 10s). Confirm they execute at the correct times. Schedule a task and cancel it before it fires. Confirm the cancelled task does not execute. Confirm no memory errors (run under valgrind if available: `valgrind --leak-check=full ./mud`).

--- a/tasks/todo/task_15_rename_lua_state_parameter.md
+++ b/tasks/todo/task_15_rename_lua_state_parameter.md
@@ -1,0 +1,63 @@
+# Rename `lua_State* l` Parameter to `lua_State* lua`
+
+**Priority:** 15
+**Created:** 2026-03-16
+**Effort:** Low (mechanical rename)
+**Risk:** None
+**Warnings eliminated:** ~157 `[readability-identifier-length]`
+
+## What
+
+Rename the `lua_State* l` parameter to `lua_State* lua` across all Lua binding files in `src/lua/`.
+
+## Why
+
+Every Lua API callback function uses `l` as its `lua_State*` parameter name. This triggers 157 `readability-identifier-length` warnings from clang-tidy (the single largest warning category in the build). The name `lua` is unambiguous, requires no change to semantics, and makes the parameter immediately recognisable.
+
+## How
+
+The rename is mechanical. Every affected file has the same pattern: a function declared `static int lua_something(lua_State* l)` with uses of `l` throughout the body.
+
+### Files to update
+
+Run this search to confirm all call sites:
+```
+grep -rn "\blua_State\* l\b\|[^a-z]l\b" src/lua/
+```
+
+**Files affected** (confirmed from build output):
+- `src/lua/common.c`
+- `src/lua/db_api.c`
+- `src/lua/game_api.c`
+- `src/lua/hooks.c`
+- `src/lua/log_api.c`
+- `src/lua/player_api.c`
+- `src/lua/script_api.c`
+- `src/lua/struct.c`
+- `src/config.c` (one instance: a local `lua_State* l` variable, not a parameter — rename to `lua_state`)
+
+### Approach
+
+For each file, do a careful rename of `l` → `lua` **only** where it refers to the `lua_State*`. Do not blindly replace all `l` — the letter appears in other contexts (e.g., string literals, unrelated variables).
+
+The safest approach per-file:
+1. Search for `lua_State\* l[^a-z]` to find parameter declarations — rename to `lua_State* lua`
+2. Search for `\bl\b` (word-boundary match) to find usages within function bodies — rename each to `lua`
+3. Take care not to match `l` in variable names like `val`, `level`, `list`, etc.
+
+Using a structured editor or IDE refactor (rename symbol) per function is the safest method. Alternatively, sed with word-boundary matching:
+
+```bash
+# Example for one file — review diff carefully before applying
+sed -i 's/lua_State\* l)/lua_State* lua)/g; s/\bl\b/lua/g' src/lua/game_api.c
+```
+
+This sed approach is risky due to false positives on single-letter `l`. **Review every diff** before committing.
+
+### Verification
+
+```bash
+make 2>&1 | grep "identifier-length" | grep "'l'"
+```
+
+Should return zero results. Build must produce zero errors.

--- a/tasks/todo/task_16_rename_short_identifiers_common.md
+++ b/tasks/todo/task_16_rename_short_identifiers_common.md
@@ -1,0 +1,85 @@
+# Rename Common Short Identifiers: `it`, `rc`, `db`
+
+**Priority:** 16
+**Created:** 2026-03-16
+**Effort:** Low–Medium (mechanical, widespread)
+**Risk:** None
+**Warnings eliminated:** ~86 `[readability-identifier-length]`
+
+## What
+
+Rename three high-frequency short identifiers that appear across many files:
+- `it_t it` → `it_t iter` (iterator variable — 47 occurrences)
+- `it_t it` as a parameter → `it_t iter` (5 occurrences)
+- `int rc` / `sqlite3_stmt* rc` → `result` (12 occurrences)
+- `sqlite3* db` parameter → `sqlite3* database` (22 occurrences)
+
+## Why
+
+These three names account for 86 warnings and appear across most of the codebase. They are all routine renames with clear, unambiguous replacements and zero semantic change.
+
+## How
+
+### 1. `it` → `iter` (52 occurrences across many files)
+
+`it_t it` is used as the iteration variable in every linked list traversal. Affected files (from build output):
+
+- `src/action.c`
+- `src/command.c`
+- `src/data/hash_table/hash_table.c`
+- `src/data/hash_table/hash_iterator.c`
+- `src/data/linked_list/linked_list.c`
+- `src/ecs/archetype.c`
+- `src/ecs/component.c`
+- `src/ecs/system.c`
+- `src/event.c`
+- `src/player.c`
+- `src/task.c`
+- `src/lua/game_api.c`
+- `src/lua/player_api.c`
+- `src/lua/hooks.c`
+
+In each file, replace `it_t it` with `it_t iter`, then replace all uses of the bare `it` variable (as an `it_t` value) with `iter`.
+
+Also update any function prototypes or signatures in headers that include `it_t it` as a named parameter — check `include/mud/data/linked_list/iterator.h` and related headers.
+
+Take care not to rename `it_t` (the type name) — only the variable named `it`.
+
+### 2. `rc` → `result` (12 occurrences)
+
+Used for return codes and SQLite result codes. Affected files:
+
+```
+grep -rn "\brc\b" src/
+```
+
+Expected in: `src/db.c`, `src/lua/db_api.c`, possibly `src/network/`.
+
+Replace `int rc` / `sqlite3_stmt* rc` declarations and all subsequent uses of `rc` within the same scope.
+
+### 3. `db` → `database` (22 occurrences)
+
+The `sqlite3* db` parameter name in database-related functions. Affected files:
+
+- `src/db.c` — multiple function parameters
+- `src/lua/db_api.c` — multiple function parameters
+
+```
+grep -rn "\bsqlite3\* db\b\|\bsqlite3\*db\b" src/
+grep -rn "\bdb\b" src/db.c src/lua/db_api.c
+```
+
+Replace the parameter declaration and all in-scope uses. Note that `db` may also appear as a struct field name (e.g., if `game->db` or similar exists — do not rename struct fields, only local parameters and variables).
+
+Check headers too:
+```
+grep -rn "\bsqlite3\* db\b" include/
+```
+
+### Verification
+
+```bash
+make 2>&1 | grep "identifier-length" | grep -E "'it'|'rc'|'db'"
+```
+
+Should return zero. Full build must be clean.

--- a/tasks/todo/task_17_rename_short_identifiers_contextual.md
+++ b/tasks/todo/task_17_rename_short_identifiers_contextual.md
@@ -1,0 +1,111 @@
+# Rename Remaining Short Identifiers and Exclude Third-Party Code
+
+**Priority:** 17
+**Created:** 2026-03-16
+**Effort:** Low–Medium
+**Risk:** None
+**Warnings eliminated:** ~50 `[readability-identifier-length]`
+
+## What
+
+Address the remaining scattered short identifier warnings not covered in task 16. Also exclude `src/bsd/string.c` from clang-tidy since it is third-party BSD code with intentionally terse variable names.
+
+## Why
+
+After tasks 15 and 16 there are still ~50 identifier-length warnings spread across loop counters (`i`, `j`), parser state variables (`p`), network/socket parameters (`fd`, `ps`, `op`), and single-character variables in utility code. Individually small, but eliminating them completes the identifier cleanup.
+
+## How
+
+### 1. Exclude `src/bsd/string.c` from clang-tidy
+
+`src/bsd/string.c` is a verbatim BSD `strlcpy`/`strlcat` implementation with intentionally short variable names (`d`, `s`, `n`, `s1`, `s2`, `c1`, `c2`). These should not be changed. Exclude it from clang-tidy in `CMakeLists.txt` by updating the `-header-filter` and adding a source exclusion.
+
+The cleanest approach is to add a `.clang-tidy` file in `src/bsd/` that disables all checks:
+
+**Create `src/bsd/.clang-tidy`:**
+```yaml
+---
+Checks: '-*'
+...
+```
+
+clang-tidy respects per-directory configuration files. This suppresses all warnings for files in that directory without touching `CMakeLists.txt`.
+
+### 2. Rename `i` and `j` loop counters → `idx` and `jdx`
+
+Loop counters warned about (from build output):
+- `src/data/hash_table/hash_table.c` — loop over hash buckets
+- `src/json.c` — character position loop counters (5 instances)
+- `src/log.c` — loop in log formatting
+- `src/lua/common.c` — loop counter
+- `src/network/client.c` — loop counter
+- `src/util/mudhash.c` — hex digest loop
+- `src/util/mudstring.c` — string processing loops (2 instances)
+
+In each case, rename `i` → `idx` and `j` → `jdx`. These are always simple `for` loop counters; update the declaration and all three loop clauses.
+
+### 3. Rename context-specific short names
+
+These appear in specific files only. Identify and rename each:
+
+**`p` in `src/json.c`** (parser state variable, 3 occurrences):
+```
+grep -n "\bp\b" src/json.c
+```
+Rename to `state` or `parser_state`. This is the state machine variable tracking parse progress in `parse_object` and `parse_array`.
+
+**`ps` in `src/network/`** (poll set / `struct pollfd`, 2+4=6 occurrences):
+```
+grep -rn "\bps\b" src/network/
+```
+Rename to `poll_set` or `poll_fds`.
+
+**`fd` as a parameter** (file descriptor, 4 occurrences in network code):
+```
+grep -rn "int fd\b\|int\* fd\b" src/network/
+```
+Rename to `sock_fd` or `file_fd` depending on context.
+
+**`op` in telnet/network** (telnet option code, 2 occurrences):
+```
+grep -rn "\bop\b" src/network/
+```
+Rename to `option` or `telnet_option`.
+
+**`in` parameter** (2 occurrences — likely an input parameter):
+```
+grep -rn "\bin\b" src/
+```
+Note: `in` is a reserved keyword in C++ and best avoided. Rename to `input` or `data_in`.
+
+**`w` variable** (2 occurrences):
+```
+grep -rn "\bw\b" src/
+```
+Rename based on context (likely a write buffer or width).
+
+**`c` in hash/string utilities** (7 occurrences):
+```
+grep -rn "\bc\b" src/data/ src/util/ src/network/
+```
+Rename to `byte_val` in hash function, `chr` or `ch` in string processing contexts (though clang-tidy requires 3+ characters, so use `chr` or `cur_char`).
+
+**`se`, `sb`, `tm` in `src/log.c`** (1 each):
+```
+grep -n "\bse\b\|\bsb\b\|\btm\b" src/log.c
+```
+`tm` is the `struct tm*` from `localtime` — rename to `time_info`. `se`/`sb` — rename based on what they represent.
+
+### 4. Remaining single-letter parameters (`s1`, `s2`, `c`)
+
+In network or string comparison functions. Rename to descriptive names:
+- `s1`, `s2` → `str_a`, `str_b` or `left`, `right`
+- `c` as a parameter → `chr` or `delim` based on context
+
+### Verification
+
+```bash
+make 2>&1 | grep "identifier-length"
+```
+
+After tasks 15, 16, and 17 this should return zero results (except possibly any inside `src/bsd/` which will be suppressed by the directory-level `.clang-tidy`).

--- a/tasks/todo/task_18_fix_thread_safety_warnings.md
+++ b/tasks/todo/task_18_fix_thread_safety_warnings.md
@@ -1,0 +1,99 @@
+# Fix `concurrency-mt-unsafe` Warnings
+
+**Priority:** 18
+**Created:** 2026-03-16
+**Effort:** Low–Medium
+**Risk:** Low
+**Warnings eliminated:** ~31 `[concurrency-mt-unsafe]`
+
+## What
+
+Resolve `concurrency-mt-unsafe` warnings by replacing non-thread-safe C library calls with their `_r` (reentrant) equivalents where possible, and suppressing the check for the handful of call sites where no safe alternative exists (legitimately single-threaded contexts).
+
+## Why
+
+clang-tidy flags several C standard library functions as not thread-safe. Most of these warnings are in `src/data/linked_list/linked_list.c` (`strerror` in mutex error paths) — those will disappear automatically when task 04 (remove mutex from linked_list) is completed. The remaining warnings are real and should be fixed.
+
+## Note on linked_list.c warnings
+
+**Do not fix these** as part of this task. The 16–17 warnings from `linked_list.c` (lines 74, 94, 115, 133, etc.) are all `strerror` calls inside mutex error-handling code. Task 04 removes the mutex and all associated error paths entirely, eliminating those warnings. Fix the others first; confirm linked_list.c warnings are gone after task 04.
+
+## How
+
+### 1. `localtime` → `localtime_r` in `src/log.c:42`
+
+`localtime` returns a pointer to a shared static buffer — not thread-safe.
+
+```c
+// BEFORE (log.c:42)
+struct tm* tm = localtime(&current_time);
+
+// AFTER
+struct tm time_info;
+localtime_r(&current_time, &time_info);
+```
+
+Update the `strftime` call on the next line to use `&time_info` instead of `tm`. Also rename the variable from `tm` to `time_info` (this also fixes the `identifier-length` warning for `tm` from task 17).
+
+`localtime_r` is POSIX — already available on Linux (the only supported platform per README).
+
+### 2. `strerror` → `strerror_r` in network files
+
+`strerror` uses a shared buffer. Replace with `strerror_r` which writes into a caller-provided buffer.
+
+Affected call sites:
+- `src/network/server.c` — lines 76, 84, 90, 96, 102, 128, 134, 153
+- `src/network/client.c` — lines 103, 151, 181
+- `src/network/network.c` — line 185
+- `src/game.c` — line 134 (if this is a `strerror` call; confirm)
+
+For each site the pattern is `LOG(ERROR, "%s", strerror(errno))`. Replace with:
+
+```c
+// BEFORE
+LOG(ERROR, "%s", strerror(errno));
+
+// AFTER
+char err_buf[128];
+strerror_r(errno, err_buf, sizeof err_buf);
+LOG(ERROR, "%s", err_buf);
+```
+
+If `strerror_r` appears many times in the same file, define a helper macro at the top of the file to avoid repeating the buffer declaration:
+
+```c
+#define LOG_ERRNO() do { \
+    char _err_buf[128];  \
+    strerror_r(errno, _err_buf, sizeof _err_buf); \
+    LOG(ERROR, "%s", _err_buf); \
+} while(0)
+```
+
+Then replace `LOG(ERROR, "%s", strerror(errno));` with `LOG_ERRNO();` throughout the file.
+
+Note: POSIX specifies two versions of `strerror_r` (GNU and XSI). On Linux with glibc and `_GNU_SOURCE` defined, the GNU version is used (returns `char*` rather than `int`). Check which version is active by looking at existing `#define` directives or testing. If the GNU version: `char* msg = strerror_r(errno, buf, sizeof buf); LOG(ERROR, "%s", msg);`.
+
+### 3. Suppress `getopt` in `src/config.c:66`
+
+`getopt` has no thread-safe equivalent in POSIX. The config parsing runs at startup before any game logic and is inherently single-threaded. Suppress the warning with a NOLINT comment:
+
+```c
+// NOLINT(concurrency-mt-unsafe)
+while ((opt = getopt(argc, argv, ":s:l:d:p:t:h")) != -1) {
+```
+
+### 4. Suppress `exit` in `src/game.c:134`
+
+`exit()` is flagged because it calls atexit handlers which may not be thread-safe. In a single-threaded process this is not a concern. Suppress:
+
+```c
+exit(-1); // NOLINT(concurrency-mt-unsafe)
+```
+
+### Verification
+
+After completing this task and task 04:
+```bash
+make 2>&1 | grep "concurrency-mt-unsafe"
+```
+Should return zero results.

--- a/tasks/todo/task_19_fix_deprecated_openssl_sha256.md
+++ b/tasks/todo/task_19_fix_deprecated_openssl_sha256.md
@@ -1,0 +1,91 @@
+# Fix Deprecated OpenSSL SHA256 API
+
+**Priority:** 19
+**Created:** 2026-03-16
+**Effort:** Low
+**Risk:** Low
+**Warnings eliminated:** 6 deprecation warnings (3 clang-tidy + 3 compiler)
+
+## What
+
+Replace the deprecated low-level OpenSSL SHA256 functions (`SHA256_Init`, `SHA256_Update`, `SHA256_Final`) in `src/util/mudhash.c` with the current EVP (Envelope) digest API.
+
+## Why
+
+OpenSSL deprecated the direct `SHA256_CTX` / `SHA256_Init` / `SHA256_Update` / `SHA256_Final` API in OpenSSL 3.0. These generate 6 deprecation warnings at build time (3 from clang-tidy, 3 from the compiler). The EVP API is the supported replacement and has been available since OpenSSL 1.0.
+
+## How
+
+The entire change is confined to `src/util/mudhash.c` (28 lines total).
+
+### Current code
+
+```c
+#include <openssl/sha.h>
+
+void mudhash_sha256(const char* input, char* output) {
+  assert(input);
+  assert(output);
+
+  unsigned char hash[SHA256_DIGEST_LENGTH];
+  size_t len = strnlen(input, MAX_SHA256_INPUT_LENGTH);
+
+  SHA256_CTX context;
+  SHA256_Init(&context);
+  SHA256_Update(&context, input, len);
+  SHA256_Final(hash, &context);
+
+  int i = 0;
+  for (i = 0; i < SHA256_DIGEST_LENGTH; i++) {
+    sprintf(output + (i * 2), "%02x", hash[i]);
+  }
+
+  output[SHA256_HEX_SIZE - 1] = '\0';
+}
+```
+
+### Replacement using EVP API
+
+```c
+#include <openssl/evp.h>
+
+void mudhash_sha256(const char* input, char* output) {
+  assert(input);
+  assert(output);
+
+  unsigned char hash[EVP_MAX_MD_SIZE];
+  unsigned int hash_len = 0;
+  size_t len = strnlen(input, MAX_SHA256_INPUT_LENGTH);
+
+  EVP_MD_CTX* context = EVP_MD_CTX_new();
+  EVP_DigestInit_ex(context, EVP_sha256(), NULL);
+  EVP_DigestUpdate(context, input, len);
+  EVP_DigestFinal_ex(context, hash, &hash_len);
+  EVP_MD_CTX_free(context);
+
+  for (unsigned int idx = 0; idx < hash_len; idx++) {
+    sprintf(output + (idx * 2), "%02x", hash[idx]);
+  }
+
+  output[SHA256_HEX_SIZE - 1] = '\0';
+}
+```
+
+Notes:
+- `EVP_MD_CTX_new()` / `EVP_MD_CTX_free()` manage the context on the heap. Unlike the old stack-allocated `SHA256_CTX`, it must be freed.
+- `EVP_MAX_MD_SIZE` (64 bytes) is large enough for any digest including SHA256 (32 bytes).
+- `hash_len` is populated by `EVP_DigestFinal_ex` with the actual digest length (32 for SHA256). Using it in the loop instead of the hard-coded `SHA256_DIGEST_LENGTH` is more robust.
+- The `sprintf` in the hex loop is acceptable here since `output + (idx * 2)` is always within bounds given a correctly sized output buffer. See `include/mud/util/mudhash.h` for `SHA256_HEX_SIZE` to confirm the output buffer contract.
+- The loop counter rename from `i` to `idx` also resolves the `identifier-length` warning for this variable (from task 17).
+
+### Update `CMakeLists.txt` if needed
+
+Check that `libcrypto` is already in `target_link_libraries` (it is: the existing link line includes `ssl crypto`). No CMake changes are needed.
+
+### Verification
+
+```bash
+make 2>&1 | grep -i "sha256\|deprecated\|openssl"
+```
+
+Should return zero results. Confirm the hash output is correct by adding a quick sanity check: SHA256("") should produce `e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855`.

--- a/tasks/todo/task_20_recursion_and_cognitive_complexity_warnings.md
+++ b/tasks/todo/task_20_recursion_and_cognitive_complexity_warnings.md
@@ -1,0 +1,95 @@
+# Address Recursion and Cognitive Complexity Warnings
+
+**Priority:** 20
+**Created:** 2026-03-16
+**Effort:** Medium
+**Risk:** Low
+**Warnings eliminated:** 12 (`misc-no-recursion` × 7, `readability-function-cognitive-complexity` × 5)
+
+## What
+
+Suppress legitimate `misc-no-recursion` warnings on naturally recursive functions, and reduce cognitive complexity in flagged functions where practical.
+
+## Why
+
+The JSON parser and Lua/JSON bridge are recursive by design — a recursive-descent parser for a recursive data format is the idiomatic approach. Flagging these as warnings is a false positive. The high cognitive complexity warnings on the same functions and on `network_telnet_on_input` are more meaningful and benefit from refactoring.
+
+## How
+
+### Part A — Suppress `misc-no-recursion` (7 warnings, zero code change needed)
+
+These functions are correctly recursive. Add `// NOLINT(misc-no-recursion)` to each function definition:
+
+| File | Function |
+|------|----------|
+| `src/json.c` | `json_free_json_node_t` |
+| `src/json.c` | `parse_value` |
+| `src/json.c` | `parse_object` |
+| `src/json.c` | `parse_array` |
+| `src/json.c` | `write_node_value` |
+| `src/lua/struct.c` | `lua_push_json_value` |
+| `src/lua/struct.c` | `lua_to_json_node` |
+
+Place the comment on the line of the function definition:
+
+```c
+// NOLINT(misc-no-recursion)
+static json_node_t* parse_object(const char* input, size_t len, int* pos) {
+```
+
+Alternatively, disable this check globally in `CMakeLists.txt` by adding `-misc-no-recursion` to the `-checks=` string. This is appropriate if recursion will be used in future code as well.
+
+### Part B — Reduce cognitive complexity (5 warnings)
+
+#### `write_node_value` in `src/json.c` — complexity 65 (threshold 25)
+
+This function was already improved in task 01 (boolean simplification, single snprintf). If the complexity is still above threshold after those changes, the remaining complexity comes from the `OBJECT` and `ARRAY` cases which contain nested loops and conditionals.
+
+Extract the object and array serialisation into helper functions:
+
+```c
+static int write_object_value(json_node_t* node, char* buffer, size_t len, size_t* pos);
+static int write_array_value(json_node_t* node, char* buffer, size_t len, size_t* pos);
+```
+
+`write_node_value` then delegates to these for the `OBJECT` and `ARRAY` cases, reducing its own complexity substantially.
+
+#### `parse_object` in `src/json.c` — complexity 54 (threshold 25)
+
+`parse_object` is a state machine with ~10 states, each with multiple branches. Extract the state-transition logic for each state into a small inline or static helper, or split by state group (key-parsing vs value-parsing vs separator-parsing).
+
+#### `parse_array` in `src/json.c` — complexity 40 (threshold 25)
+
+Similar to `parse_object` — extract the inner per-character dispatch into a helper function or simplify the state machine.
+
+#### `lua_to_json_node` in `src/lua/struct.c` — complexity 31 (threshold 25)
+
+This function converts a Lua value on the stack to a `json_node_t`. It switches on Lua type with nested logic. Extract each Lua type handler into a small static function:
+
+```c
+static json_node_t* json_node_from_lua_string(lua_State* lua, int stack_idx);
+static json_node_t* json_node_from_lua_number(lua_State* lua, int stack_idx);
+static json_node_t* json_node_from_lua_table(lua_State* lua, int stack_idx);
+```
+
+#### `network_telnet_on_input` in `src/network/telnet.c` — complexity 27 (threshold 25)
+
+A telnet option negotiation state machine. Extract the per-byte handling logic for each state into a dedicated static function, or simplify by consolidating similar option codes.
+
+#### `player_get_commands` in `src/player.c` — complexity 26 (threshold 25)
+
+Marginally over threshold. This function iterates command groups and matches commands by name. Extract the inner command-matching loop into a helper:
+
+```c
+static command_t* find_command_in_group(command_group_t* group,
+                                         hash_table_t* commands,
+                                         const char* name);
+```
+
+### Verification
+
+```bash
+make 2>&1 | grep "misc-no-recursion\|cognitive-complexity"
+```
+
+Should return zero results after Part A suppressions and Part B refactoring. All extracted functions should be `static` (file-local). Build must remain clean with no new warnings.

--- a/tasks/todo/task_2_remove_null_guards_before_free.md
+++ b/tasks/todo/task_2_remove_null_guards_before_free.md
@@ -1,0 +1,57 @@
+# Remove Redundant NULL Guards Before `free`
+
+**Priority:** 02
+**Created:** 2026-03-16
+**Effort:** Low
+**Risk:** None
+
+## What
+
+Remove all `if (ptr != NULL) { free(ptr); }` patterns throughout the codebase, replacing them with a direct `free(ptr)` call.
+
+## Why
+
+The C standard (C11 §7.22.3.3) guarantees that `free(NULL)` is a no-op. The NULL guards add visual noise, make cleanup code look more complex than it is, and create a false impression that `free(NULL)` would be dangerous. Removing them reduces line count and makes teardown functions easier to read.
+
+## How
+
+Search for the pattern across all `.c` files:
+
+```
+grep -rn "if (.*!= NULL)" src/
+grep -rn "if (.*)" src/ | grep free
+```
+
+For each match, check if the body is solely a `free()` or a `free_X_t()` call. If so, unwrap it.
+
+### Known locations
+
+**`src/player.c:50-52`**
+```c
+// BEFORE
+if (player->username != NULL) {
+    free(player->username);
+}
+
+// AFTER
+free(player->username);
+```
+
+**`src/player.c:54-56`**
+```c
+// BEFORE
+if (player->command_groups != NULL) {
+    free_linked_list_t(player->command_groups);
+}
+
+// AFTER
+free_linked_list_t(player->command_groups);
+```
+
+Note: `free_linked_list_t` currently asserts its argument is non-null (`assert(list)` on line 37 of `linked_list.c`). Before removing the guard here, either:
+- Add a NULL early-return to `free_linked_list_t` before the assert, or
+- Keep the guard only for functions that assert non-null internally.
+
+The same consideration applies anywhere a custom `free_X_t` function is called conditionally — check whether that function has an `assert` at the top. If it does, either update the assert to a guard (`if (!x) return;`) or keep the NULL check at the call site. Prefer updating the free functions to handle NULL gracefully, which is the more conventional C pattern.
+
+Apply consistently across `src/game.c`, `src/event.c`, and any other files where the pattern appears.

--- a/tasks/todo/task_3_json_serializer_refactor.md
+++ b/tasks/todo/task_3_json_serializer_refactor.md
@@ -1,0 +1,73 @@
+# `json.c` Serializer: Collapse Double-`snprintf` Pattern
+
+**Priority:** 03
+**Created:** 2026-03-16
+**Effort:** Medium
+**Risk:** Low
+
+## What
+
+Rewrite the value-serialization switch in `src/json.c` to eliminate the two-call `snprintf`-then-`sprintf` pattern, replacing each pair with a single `snprintf` call. Also simplify the redundant boolean branch.
+
+## Why
+
+The current pattern calls `snprintf` twice for every value written: once with a NULL buffer to measure the required length, then again (as an unsafe `sprintf`) to actually write. This is unnecessary — `snprintf` already writes to the buffer and returns the would-be length, so the two operations can always be merged into one. The redundant calls double the work and the unsafe `sprintf` calls undermine the bounds check that precedes them.
+
+Additionally, the `BOOLEAN` case checks `== true` and then separately checks `== false`, with no `else`. This is needlessly verbose for a two-state value.
+
+## How
+
+### The general pattern replacement
+
+Every branch in the switch (approximately lines 722–855 of `src/json.c`) currently looks like:
+
+```c
+// BEFORE
+if ((val_len = snprintf(NULL, 0, fmt, arg)) > len - *pos) {
+    return -1;
+}
+sprintf(buffer + *pos, fmt, arg);
+*pos += val_len;
+
+// AFTER
+val_len = snprintf(buffer + *pos, len - *pos, fmt, arg);
+if (val_len < 0 || (size_t)val_len >= len - *pos) {
+    return -1;
+}
+*pos += val_len;
+```
+
+The `snprintf` return value semantics: returns the number of characters that *would* have been written excluding the null terminator. If this value is >= the buffer size passed, the output was truncated (or there was no room). Checking `>= len - *pos` catches both truncation and the edge case where the write would exactly fill the remaining space (leaving no room for a null terminator that downstream code might depend on).
+
+Apply this replacement to all branches: `STRING`, `NUMBER`, `BOOLEAN`, `NIL`, `OBJECT` key serialization, `ARRAY` serialization, and any other call sites. Search for `sprintf(buffer` in `src/json.c` to find every instance.
+
+### BOOLEAN simplification
+
+```c
+// BEFORE
+case BOOLEAN:
+    if (node->value->boolean == true) {
+        // snprintf + sprintf block for TRUE_STR
+        break;
+    }
+    if (node->value->boolean == false) {
+        // snprintf + sprintf block for FALSE_STR
+        break;
+    }
+    break;
+
+// AFTER
+case BOOLEAN: {
+    const char* bool_str = node->value->boolean ? TRUE_STR : FALSE_STR;
+    val_len = snprintf(buffer + *pos, len - *pos, "%s", bool_str);
+    if (val_len < 0 || (size_t)val_len >= len - *pos) {
+        return -1;
+    }
+    *pos += val_len;
+    break;
+}
+```
+
+### Verification
+
+After the change, run a round-trip test: parse a known JSON string, serialize it back, and compare to the original. The existing `dist/` game scripts that use JSON push/pull via Lua can serve as a functional smoke test. Connect a client and exercise any Lua code that calls `json.serialize`.

--- a/tasks/todo/task_4_remove_linked_list_mutex.md
+++ b/tasks/todo/task_4_remove_linked_list_mutex.md
@@ -1,0 +1,57 @@
+# Remove `pthread_mutex` from `linked_list_t`
+
+**Priority:** 04
+**Created:** 2026-03-16
+**Effort:** Medium
+**Risk:** Low
+
+## What
+
+Remove the `pthread_mutex_t` field from `linked_list_t` and all associated lock/unlock calls from `list_add`, `list_remove`, and the other list operations in `src/data/linked_list/linked_list.c`.
+
+## Why
+
+The game loop in `src/game.c` is single-threaded — there is no thread creation anywhere in the codebase. Every `list_add` and `list_remove` call currently acquires and releases a mutex unnecessarily. This adds:
+
+- ~40 bytes of wasted memory per list instance (a `pthread_mutex_t` on Linux)
+- A lock/unlock overhead on every insert and remove
+- Error-handling code paths in `list_add`/`list_remove` for mutex failure that can never meaningfully recover
+- Complexity in `init_linked_list` and `free_linked_list_t` for mutex init/destroy
+
+If threading is needed in the future it should be applied at the game-state level, not on every individual list.
+
+## How
+
+### 1. Update the struct — `src/data/linked_list/linked_list.h`
+
+Remove the `pthread_mutex_t mutex` field from `linked_list_t`.
+
+Remove the `#include <pthread.h>` if it is no longer used anywhere in the header.
+
+### 2. Update `src/data/linked_list/linked_list.c`
+
+**`init_linked_list`**: Remove `pthread_mutex_init(&list->mutex, NULL)`.
+
+**`free_linked_list_t`**: Remove `pthread_mutex_destroy(&list->mutex)`.
+
+**`list_add`**: Remove the `pthread_mutex_lock` call, the error-log-and-return block, and the `pthread_mutex_unlock` call with its error block. The function body then just performs the pointer manipulation. Because the error paths around mutex failure currently return `-1`, and callers do not check the return value of `list_add` consistently, removing them simplifies the function to one that cannot fail (unless `calloc` fails — see note below).
+
+**`list_remove`** and any other operations that lock the mutex: apply the same removal.
+
+Remove `#include <errno.h>` and `#include <string.h>` from `linked_list.c` if they were only needed for the mutex error logging.
+
+### 3. Update `CMakeLists.txt`
+
+Check whether `-lpthread` is in `target_link_libraries`. If `pthread` is no longer used anywhere after this change, remove it. Search all `.c` files for remaining `pthread_` usage before removing.
+
+```
+grep -rn "pthread_" src/
+```
+
+### Note on `calloc` failure in `list_add`
+
+Currently `list_add` calls `node_new()` which calls `calloc`. If `calloc` returns NULL the code will crash on `node->data = value`. This is a pre-existing issue independent of the mutex removal. Optionally add a NULL check on the return of `node_new()` and return `-1` if it fails, making the function's error return meaningful. Callers should then check the return value.
+
+### Verification
+
+Build cleanly (`make` in `build/`) with no new warnings. Run the game and connect a test client to exercise list operations (player connects → commands → disconnects exercises add/remove on the player list).

--- a/tasks/todo/task_5_flatten_hash_node_allocations.md
+++ b/tasks/todo/task_5_flatten_hash_node_allocations.md
@@ -1,0 +1,111 @@
+# Flatten `hash_node_t` Allocations
+
+**Priority:** 05
+**Created:** 2026-03-16
+**Effort:** Medium
+**Risk:** Low
+
+## What
+
+Combine the two heap allocations made per `hash_table_insert` call (one for the `hash_node_t` struct, one for the key string via `strdup`) into a single allocation using a flexible array member.
+
+## Why
+
+Every insert currently allocates memory twice: `create_hash_node_t()` allocates the node struct, and `strdup(key)` allocates a copy of the key string separately. These two objects always have the same lifetime (freed together in `hash_node_free`). A single allocation is simpler, reduces heap fragmentation, and improves cache locality (the key string is adjacent to the struct fields that reference it).
+
+## How
+
+### 1. Update `hash_node_t` — `src/data/hash_table/hash_node.h`
+
+Replace the `char* key` pointer field with a C99 flexible array member:
+
+```c
+// BEFORE
+typedef struct hash_node_t {
+    char* key;
+    void* value;
+    void (*deallocator)(void*);
+} hash_node_t;
+
+// AFTER
+typedef struct hash_node_t {
+    void* value;
+    void (*deallocator)(void*);
+    char key[];   // flexible array member — key string stored inline
+} hash_node_t;
+```
+
+### 2. Update `hash_node_new` — `src/data/hash_table/hash_node.c`
+
+Change `create_hash_node_t` (or `hash_node_new`) to accept the key and allocate the combined struct+key in one call:
+
+```c
+// BEFORE
+hash_node_t* create_hash_node_t(void) {
+    return calloc(1, sizeof *node);
+}
+
+// AFTER
+hash_node_t* hash_node_new(const char* key, size_t key_len) {
+    hash_node_t* node = calloc(1, sizeof *node + key_len + 1);
+    if (!node) return NULL;
+    memcpy(node->key, key, key_len);
+    node->key[key_len] = '\0';
+    return node;
+}
+```
+
+The `key_len` argument avoids a second `strlen` call since the caller already knows it.
+
+### 3. Update `hash_node_free` — `src/data/hash_table/hash_node.c`
+
+Remove the separate `free(node->key)` call — the key is now part of the same allocation as the struct:
+
+```c
+// BEFORE
+void node_free(hash_node_t* node) {
+    assert(node);
+    if (node->deallocator) node->deallocator(node->value);
+    free(node->key);   // REMOVE THIS
+    free(node);
+}
+
+// AFTER
+void hash_node_free(hash_node_t* node) {
+    assert(node);
+    if (node->deallocator) node->deallocator(node->value);
+    free(node);
+}
+```
+
+### 4. Update `hash_table_insert` — `src/data/hash_table/hash_table.c`
+
+Remove the `strdup(key)` call and the now-unused `len` local variable. Pass the key directly to `hash_node_new`:
+
+```c
+// BEFORE
+char* hash_key = strdup(key);
+size_t len = strnlen(hash_key, MAX_KEY_LENGTH - 1);
+// ... truncation block (already removed by task 01) ...
+hash_node_t* hash_node = create_hash_node_t();
+hash_node->key = hash_key;
+
+// AFTER
+size_t key_len = strnlen(key, MAX_KEY_LENGTH);
+hash_node_t* hash_node = hash_node_new(key, key_len);
+if (!hash_node) return -1;
+```
+
+### 5. Review all other access to `node->key`
+
+Search for `node->key` and `hash_node->key` across the codebase to confirm no other code frees or reassigns the key field:
+
+```
+grep -rn "->key" src/data/hash_table/
+```
+
+The key is read in `hash_table_delete` and `hash_table_get` for comparison — these remain unchanged since `node->key` still works as a `char*` (flexible array members decay to pointers).
+
+### Verification
+
+Build cleanly. Run the game and exercise operations that use the hash table heavily: entity registration, component lookup, system registration. These all go through the hash table.

--- a/tasks/todo/task_6_inline_bounded_strings.md
+++ b/tasks/todo/task_6_inline_bounded_strings.md
@@ -1,0 +1,70 @@
+# Inline Bounded Strings Into Owner Structs
+
+**Priority:** 06
+**Created:** 2026-03-16
+**Effort:** Medium
+**Risk:** Low–Medium
+
+## What
+
+Replace heap-allocated `char*` fields (set via `strdup`) with fixed `char[]` arrays for strings whose maximum length is known at compile time and whose lifetime is tied to the owning struct.
+
+## Why
+
+Several structs store strings as `char*` fields populated by `strdup`. This means every struct creation does an extra allocation, every struct teardown needs a conditional free (or just a free), and there is always a risk of forgetting the free. For strings with a bounded size (UUIDs are always exactly 36 characters; usernames have a configurable max), an inline array eliminates the separate allocation entirely, makes the struct self-contained, and removes a class of potential leak.
+
+## How
+
+### Priority targets
+
+**UUID strings** — always exactly 36 characters plus a null terminator (37 bytes). Any struct storing a UUID as `char* uuid` set via `strdup(uuid_string)` is a candidate. Affected structs likely include `command_t`, `action_t`, and others. Check by searching:
+
+```
+grep -rn "char\* uuid" include/
+grep -rn "strdup.*uuid" src/
+```
+
+Replace with:
+```c
+// BEFORE
+char* uuid;
+// set via: s->uuid = strdup(uuid_str(...));
+// freed via: free(s->uuid);
+
+// AFTER
+#define UUID_STR_LEN 36
+char uuid[UUID_STR_LEN + 1];
+// set via: strlcpy(s->uuid, uuid_str(...), sizeof s->uuid);
+// freed: nothing, freed with the struct
+```
+
+**`task_t.name`** — task names are developer-defined identifiers. Determine the maximum expected length, add a `#define TASK_NAME_MAX_LEN` constant (64 is reasonable), and change:
+```c
+// BEFORE (src/task.c and include/mud/task.h)
+char* name;
+// set via: t->name = strdup(name);
+// freed via: free(t->name);
+
+// AFTER
+char name[TASK_NAME_MAX_LEN + 1];
+// set via: strlcpy(t->name, name, sizeof t->name);
+```
+
+**`player_t.username`** — if a `MAX_USERNAME_LEN` constant already exists or can be defined, apply the same transformation. Check `src/player.c` and `include/mud/player.h`.
+
+### Steps for each field
+
+1. Update the header to change `char* field` → `char field[MAX_LEN + 1]` and add or reference the relevant max-length constant.
+2. Update the constructor (`create_X_t` or `new_X`) to use `strlcpy(s->field, src, sizeof s->field)` instead of `strdup`.
+3. Update the destructor (`free_X_t`) to remove the `free(s->field)` call.
+4. Search for all other places where the field is assigned (not just in the constructor) and update those to `strlcpy` as well.
+
+```
+grep -rn "->uuid\s*=" src/
+grep -rn "->name\s*=" src/
+grep -rn "->username\s*=" src/
+```
+
+### Caution
+
+Do not apply this to strings that are genuinely variable-length and potentially large (e.g., player input buffers, SQL query strings, JSON output). Only apply where an upper bound is natural and tight. If the right max length is unclear, leave the field as `char*` rather than picking an arbitrary size.

--- a/tasks/todo/task_7_naming_convention_standardisation.md
+++ b/tasks/todo/task_7_naming_convention_standardisation.md
@@ -1,0 +1,68 @@
+# Naming Convention Standardisation
+
+**Priority:** 07
+**Created:** 2026-03-16
+**Effort:** High
+**Risk:** Medium (wide rename scope — do per subsystem)
+
+## What
+
+Establish and apply a single consistent naming convention for constructor/destructor functions, error return values, and deallocator wrappers across the entire codebase.
+
+## Why
+
+The codebase currently uses at least three different naming schemes for equivalent operations:
+
+| Pattern | Where |
+|---|---|
+| `create_X_t()` / `free_X_t()` | data structures (`linked_list`, `hash_table`, etc.) |
+| `ecs_new_X_t()` / `ecs_free_X_t()` | ECS (`entity`, `component`, `system`, `archetype`) |
+| No prefix, just `new_X()` | some lower-level types |
+
+The `_t` suffix on function names is unconventional — in C, `_t` is a naming convention reserved for types (and POSIX reserves identifiers ending in `_t` for future use). Function names using it are misleading.
+
+Error return values are also inconsistent: most functions return `0` for success and `-1` for error, but several in `db.c` return `0` in error paths.
+
+## How
+
+### Agreed convention (confirm with developer before executing)
+
+- Constructor: `mud_X_new()` — allocates and initialises, returns pointer or NULL on failure
+- Destructor: `mud_X_free()` — frees; accepts NULL gracefully (like `free()`)
+- Error returns: `0` = success, `-1` = error, consistently
+
+Alternatively, if keeping subsystem prefixes is preferred: `game_X_new` / `ecs_X_new` / `net_X_new` etc. The important thing is that the pattern is consistent within and ideally across subsystems.
+
+### Execution approach — do one subsystem per commit
+
+**Do not do this in one large commit.** Each rename should be one focused commit so diffs are reviewable and bisectable.
+
+Suggested order (least to most interconnected):
+
+1. `src/data/linked_list/` — rename `create_linked_list_t` → `linked_list_new`, `free_linked_list_t` → `linked_list_free`, etc.
+2. `src/data/hash_table/` — same pattern
+3. `src/data/queue/` — same pattern
+4. `src/ecs/entity.c` — `ecs_new_entity_t` → `entity_new` etc.
+5. `src/ecs/component.c`, `system.c`, `archetype.c`
+6. `src/player.c`, `src/task.c`, `src/command.c`, `src/action.c`, `src/event.c`
+
+For each subsystem:
+```bash
+# Find all usages before renaming
+grep -rn "create_linked_list_t\|free_linked_list_t" src/ include/
+# Update header first, then implementation, then callers
+```
+
+### Error return consistency in `db.c`
+
+Search `src/db.c` for functions that return `0` in error paths where `-1` is the convention:
+
+```
+grep -n "return 0" src/db.c
+```
+
+Review each return site in context. Where a function returns `0` after an error (failed sqlite step, NULL result, etc.), change to `return -1`. Update callers if they check the return value.
+
+### Verification
+
+After each subsystem rename: `make` in the `build/` directory must produce zero errors and zero new warnings (clang-tidy runs automatically). The rename is purely mechanical so no behavioural change is expected.

--- a/tasks/todo/task_8_designated_initialisers.md
+++ b/tasks/todo/task_8_designated_initialisers.md
@@ -1,0 +1,67 @@
+# Use Designated Initialisers for Struct Construction
+
+**Priority:** 08
+**Created:** 2026-03-16
+**Effort:** Low (apply incrementally)
+**Risk:** None
+
+## What
+
+Where constructor functions initialise struct fields individually after a `calloc`, use C99 designated initialisers to make the non-zero fields explicit and the intent clearer.
+
+## Why
+
+The current pattern is:
+```c
+player_t* p = calloc(1, sizeof *p);
+p->socket = -1;
+p->state = STATE_NEW;
+// (username, command_groups left as NULL by calloc)
+```
+
+This requires reading every following line to know the full initial state. With a compound literal assignment after `calloc`, all non-zero initial values are visible at a glance:
+
+```c
+player_t* p = calloc(1, sizeof *p);
+if (!p) return NULL;
+*p = (player_t){ .socket = -1, .state = STATE_NEW };
+```
+
+Fields not listed in the designated initialiser are zero-initialised by the compound literal, consistent with what `calloc` provides.
+
+## How
+
+This is an incremental change — apply it whenever a constructor function is being touched for another reason, rather than as a dedicated sweep.
+
+### Pattern to apply
+
+```c
+// BEFORE
+foo_t* f = calloc(1, sizeof *f);
+f->field_a = VALUE_A;
+f->field_b = VALUE_B;
+// field_c left NULL/0 by calloc
+return f;
+
+// AFTER
+foo_t* f = calloc(1, sizeof *f);
+if (!f) return NULL;
+*p = (foo_t){ .field_a = VALUE_A, .field_b = VALUE_B };
+return f;
+```
+
+Note: the `if (!f) return NULL` NULL check is worth adding at the same time. `calloc` can return NULL if allocation fails and currently these failures are silently ignored in most constructors.
+
+### Files where this applies most clearly
+
+- `src/player.c` — `create_player_t`
+- `src/task.c` — `create_task_t`
+- `src/command.c` — `create_command_t`, `create_command_group_t`
+- `src/action.c` — `create_action_t`
+- `src/event.c` — any event allocation
+- `src/ecs/entity.c`, `component.c`, `system.c`
+
+### Do not apply where
+
+- The struct has many fields all left at their zero values — `calloc` already handles this cleanly.
+- The initialisation logic is conditional or involves non-trivial expressions better left as sequential statements.

--- a/tasks/todo/task_9_deallocator_macro.md
+++ b/tasks/todo/task_9_deallocator_macro.md
@@ -1,0 +1,79 @@
+# Collapse Deallocator Wrapper Functions Into a Macro
+
+**Priority:** 09
+**Created:** 2026-03-16
+**Effort:** Low
+**Risk:** None
+
+## What
+
+Replace the repeated `deallocate_X(void*)` wrapper functions with a single macro that generates them.
+
+## Why
+
+The data structures (`linked_list_t`, `hash_table_t`) store `void*` values and call a `void (*deallocator)(void*)` function pointer to free them. Because the actual free functions take typed pointers (`free_player_t(player_t*)`), a small wrapper is needed to do the cast. This wrapper is currently written out by hand for every type:
+
+```c
+void deallocate_player(void* value) {
+    assert(value);
+    player_t* player = (player_t*)value;
+    free_player_t(player);
+}
+```
+
+This pattern repeats ~10 times across the codebase. A macro generates the same code with one line per type.
+
+## How
+
+### 1. Add the macro — `include/mud/data/deallocate.h` (or a new `include/mud/util/macros.h`)
+
+```c
+/*
+ * Generates a void* deallocator wrapper for use as a data structure
+ * deallocator function pointer.
+ *
+ * Usage: DEFINE_DEALLOCATOR(deallocate_player, player_t, free_player_t)
+ */
+#define DEFINE_DEALLOCATOR(fn_name, type, free_fn)  \
+    void fn_name(void* _v) {                         \
+        assert(_v);                                  \
+        free_fn((type*)_v);                          \
+    }
+```
+
+### 2. Replace existing deallocator definitions
+
+Find all existing deallocator functions:
+
+```
+grep -rn "^void deallocate_" src/
+```
+
+For each one, delete the function body and replace with the macro invocation in the corresponding `.c` file:
+
+```c
+// BEFORE
+void deallocate_player(void* value) {
+    assert(value);
+    player_t* player = (player_t*)value;
+    free_player_t(player);
+}
+
+// AFTER
+DEFINE_DEALLOCATOR(deallocate_player, player_t, free_player_t)
+```
+
+The function declarations in the corresponding `.h` files remain unchanged — the macro expands to a definition, not a declaration, so callers see no difference.
+
+### 3. Known deallocators to replace
+
+- `deallocate_player` in `src/player.c`
+- `deallocate_command` / `deallocate_command_group` in `src/command.c`
+- `deallocate_action` in `src/action.c`
+- `deallocate_linked_list_t` in `src/data/linked_list/linked_list.c`
+- Any ECS deallocators in `src/ecs/`
+- Any others found by the grep above
+
+### Verification
+
+`make` must produce zero errors. The macro expands to identical code so no behavioural change is expected. Verify the header include chain is correct (the macro uses `assert`, so the file using the macro must include `<assert.h>`).


### PR DESCRIPTION
20 tasks identified across four areas of work:

Bug fixes and correctness (tasks 1-3): off-by-one writes, unsafe sprintf in the JSON serialiser, and null guard cleanup.

Memory and data structure improvements (tasks 4-14): remove unnecessary mutex from linked_list_t, flatten hash_node_t allocations, inline bounded strings, introduce a ptr_array_t dynamic array utility, and replace linked lists with flat arrays on the ECS hot paths (archetypes, systems, tasks).

Code quality and style (tasks 7-9, 15-17): naming convention standardisation, designated initialisers, deallocator macro, and renaming of short identifiers throughout the codebase.

Warning remediation (tasks 18-20): thread-safety calls, deprecated OpenSSL SHA256 API, and suppression of false-positive recursion warnings alongside reduction of high cognitive complexity functions.